### PR TITLE
Unit Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ _deps
 wjsonformat
 !wjsonformat/
 wjson_core_test
+wjsoncompact

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ wjsonformat
 !wjsonformat/
 wjson_core_test
 wjsoncompact
+!wjsoncompact/

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ _deps
 // Compiled Code
 wjsonformat
 !wjsonformat/
+wjson_core_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,3 +12,4 @@ include_directories(AFTER lib)
 
 # build executables
 add_executable(wjsonformat cli-utils/wjsonformat/main.cpp)
+add_executable(wjsoncompact cli-utils/wjsoncompact/main.cpp)

--- a/cli-utils/wjsoncompact/main.cpp
+++ b/cli-utils/wjsoncompact/main.cpp
@@ -8,7 +8,7 @@
 #include <core/parser.cpp>
 #include <core/ast.cpp>
 
-#include "printer.h"
+#include "wjsoncompact.cpp"
 
 using namespace std;
 

--- a/cli-utils/wjsoncompact/main.cpp
+++ b/cli-utils/wjsoncompact/main.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <fstream>
+
+// libwjson modules
+#include <core/token.cpp>
+#include <core/json_exception.cpp>
+#include <core/lexer.cpp>
+#include <core/parser.cpp>
+#include <core/ast.cpp>
+
+#include "printer.h"
+
+using namespace std;
+
+
+int main(int argc, char* argv[])
+{
+  // use standard input if no input file given
+  istream* input_stream = &cin;
+  if (argc == 2)
+    input_stream = new ifstream(argv[1]);
+
+  // create the lexer & parser
+  Lexer lexer(*input_stream);
+  Parser parser(lexer);
+
+  // read each token in the file until EOS or error
+  try {
+    JSONDocument ast_root_node;
+    parser.parse(ast_root_node);
+    Printer printer(cout);
+    ast_root_node.accept(printer);
+  } catch (JSONException e) {
+    cerr << e.to_string() << endl;
+    exit(1);
+  }
+  // clean up the input stream
+  if (input_stream != &cin)
+    delete input_stream;
+}

--- a/cli-utils/wjsoncompact/wjsoncompact.cpp
+++ b/cli-utils/wjsoncompact/wjsoncompact.cpp
@@ -1,0 +1,105 @@
+// Since this declares a definition of the Printer class, we need to typeguard it generically
+#ifndef PRINTER_CPP
+#define PRINTER_CPP
+
+// libwjson core modules
+#include <printer/printer.h>
+
+
+// constructors
+Printer::Printer(std::ostream& output_stream)
+: out(output_stream), indent_size(0), indent_char(' ') {}
+
+Printer::Printer(std::ostream& output_stream, const int& indent)
+: out(output_stream), indent_size(indent), indent_char(' ') {}
+
+Printer::Printer(std::ostream& output_stream, const int& indent_width, const char& indent_character)
+: out(output_stream), indent_size(indent_width), indent_char(indent_character) {}
+
+
+// Indent managers
+void Printer::inc_indent() {
+}
+
+void Printer::dec_indent() {
+}
+
+std::string Printer::get_indent() {
+	return "";
+}
+
+// top-level
+void Printer::visit(JSONDocument& node)
+{
+	node.root->accept(*this);
+	out.flush();
+}
+
+void Printer::visit(JSON& node)
+{
+	if(!node.records.size())
+	{
+		out << "{}";
+		return;
+	}
+	inc_indent();
+	out << "{";
+	auto it = node.records.begin();
+	(*it)->accept(*this);
+	++it;
+	for(; it != node.records.end(); ++it)
+	{
+		out << ",";
+		(*it)->accept(*this);
+	}
+	dec_indent();
+	out << get_indent() << "}";
+}
+
+void Printer::visit(Record& node)
+{
+	out << get_indent();
+	out << '"' << node.key.lexeme() << '"';
+	out << ":";
+	node.value->accept(*this);
+}
+
+void Printer::visit(SimpleRValue& node)
+{
+	switch(node.type)
+	{
+		case LITERAL_TYPE:
+		case NUMBER_TYPE:
+			out << node.value.lexeme();
+			break;
+		case STRING_TYPE:
+			out << '"' << node.value.lexeme() << '"';
+			break;
+		default:
+			break; // no other types
+	}
+}
+
+void Printer::visit(Array& node)
+{
+	if(!node.values.size())
+	{
+		out << "[]";
+		return;
+	}
+	inc_indent();
+	out << "[" << get_indent();
+	auto it = node.values.begin();
+	(*it)->accept(*this);
+	++it;
+	for(; it != node.values.end(); ++it)
+	{
+		out << "," << get_indent();
+		(*it)->accept(*this);
+	}
+	dec_indent();
+	out << get_indent() << "]";
+}
+
+
+#endif // ifndef PRINTER_CPP

--- a/cli-utils/wjsonformat/main.cpp
+++ b/cli-utils/wjsonformat/main.cpp
@@ -2,11 +2,11 @@
 #include <fstream>
 
 // libwjson modules
-#include <core/token.h>
-#include <core/json_exception.h>
-#include <core/lexer.h>
-#include <core/parser.h>
-#include <core/ast.h>
+#include <core/token.cpp>
+#include <core/json_exception.cpp>
+#include <core/lexer.cpp>
+#include <core/parser.cpp>
+#include <core/ast.cpp>
 
 #include "printer.h"
 

--- a/cli-utils/wjsonformat/main.cpp
+++ b/cli-utils/wjsonformat/main.cpp
@@ -8,7 +8,7 @@
 #include <core/parser.cpp>
 #include <core/ast.cpp>
 
-#include "printer.h"
+#include "wjsonformat.cpp"
 
 using namespace std;
 

--- a/cli-utils/wjsonformat/wjsonformat.cpp
+++ b/cli-utils/wjsonformat/wjsonformat.cpp
@@ -1,47 +1,34 @@
-#ifndef PRINTER_H
-#define PRINTER_H
-
-#include <iostream>
-#include <string>
+// Since this declares a definition of the Printer class, we need to typeguard it generically
+#ifndef PRINTER_CPP
+#define PRINTER_CPP
 
 // libwjson core modules
-#include <core/token.h>
-#include <core/ast.h>
+#include <printer/printer.h>
 
 
-class Printer : public Visitor
-{
-public:
-	// constructors
-	Printer(std::ostream& output_stream)
-	: out(output_stream), indent_size(1), indent_char('\t') {}
+// constructors
+Printer::Printer(std::ostream& output_stream)
+: out(output_stream), indent_size(1), indent_char('\t') {}
 
-	Printer(std::ostream& output_stream, const int& indent)
-	: out(output_stream), indent_size(indent), indent_char(' ') {}
+Printer::Printer(std::ostream& output_stream, const int& indent)
+: out(output_stream), indent_size(indent), indent_char(' ') {}
 
-	Printer(std::ostream& output_stream, const int& indent_width, const char& indent_character)
-	: out(output_stream), indent_size(indent_width), indent_char(indent_character) {}
+Printer::Printer(std::ostream& output_stream, const int& indent_width, const char& indent_character)
+: out(output_stream), indent_size(indent_width), indent_char(indent_character) {}
 
 
-	// top-level
-	void visit(JSONDocument& node);
-	void visit(JSON& node);
-	void visit(Record& node);
-	void visit(RValue& node);
-	void visit(SimpleRValue& node);
-	void visit(Array& node);
+// Indent managers
+void Printer::inc_indent() {
+	curr_indent += indent_size;
+}
 
-private:
-	const int indent_size;
-	const char indent_char;
+void Printer::dec_indent() {
+	curr_indent -= indent_size;
+}
 
-	std::ostream& out;
-	int curr_indent = 0;
-
-	void inc_indent() {curr_indent += indent_size;}
-	void dec_indent() {curr_indent -= indent_size;}
-	std::string get_indent() {return std::string(curr_indent, indent_char);}
-};
+std::string Printer::get_indent() {
+	return std::string(curr_indent, indent_char);
+}
 
 // top-level
 void Printer::visit(JSONDocument& node)
@@ -118,4 +105,4 @@ void Printer::visit(Array& node)
 }
 
 
-#endif
+#endif // ifndef PRINTER_CPP

--- a/lib/core/ast.cpp
+++ b/lib/core/ast.cpp
@@ -1,0 +1,77 @@
+#ifndef AST_CPP
+#define AST_CPP
+
+#include "ast.h"
+
+
+//----------------------------------------------------------------------
+// Top-level Abstract AST Nodes
+//----------------------------------------------------------------------
+
+// Record
+void Record::accept(Visitor& v) {
+  v.visit(*this);
+}
+
+
+// JSONDocument
+void JSONDocument::accept(Visitor& v) {
+  v.visit(*this);
+}
+
+
+//----------------------------------------------------------------------
+// RValue nodes
+//----------------------------------------------------------------------
+
+// JSON
+// cleanup memory
+JSON::~JSON() {
+  for (Record* d : records) delete d;
+}
+
+// return first token (first primitive value)
+Token JSON::first_token() {
+  return this->records.size()
+    ? this->records.front()->key
+    : this->rbrace_token;
+}
+
+// visitor access
+void JSON::accept(Visitor& v) {
+  v.visit(*this);
+}
+
+
+// Array
+// cleanup memory
+Array::~Array() {
+  for (RValue* v : values) delete v;
+}
+
+// return first token (first primitive value)
+Token Array::first_token() {
+  return this->values.size()
+    ? this->values.front()->first_token()
+    : this->rbracket_token;
+}
+
+// visitor access
+void Array::accept(Visitor& v) {
+  v.visit(*this);
+}
+
+
+// SimpleRValue
+// return first token
+Token SimpleRValue::first_token() {
+  return value;
+}
+
+// visitor access
+void SimpleRValue::accept(Visitor& v) {
+  v.visit(*this);
+}
+
+
+#endif // ifndef AST_CPP

--- a/lib/core/ast.h
+++ b/lib/core/ast.h
@@ -24,11 +24,11 @@ class Array;
 class Visitor {
 public:
   // top-level
-  virtual void visit(JSON& node) = 0;
-  virtual void visit(JSONDocument& node) = 0;
-  virtual void visit(Record& node) = 0;
-  virtual void visit(SimpleRValue& node) = 0;
-  virtual void visit(Array& node) = 0;
+  virtual void visit(JSON&) = 0;
+  virtual void visit(JSONDocument&) = 0;
+  virtual void visit(Record&) = 0;
+  virtual void visit(SimpleRValue&) = 0;
+  virtual void visit(Array&) = 0;
 };
 
 
@@ -41,7 +41,7 @@ class ASTNode
 {
   public:
     virtual ~ASTNode() {};
-    virtual void accept(Visitor& v) = 0;
+    virtual void accept(Visitor&) = 0;
 };
 
 
@@ -61,7 +61,7 @@ class Record : public ASTNode
     Token key;
     RValue* value;
     // visitor access
-    void accept(Visitor& v) {v.visit(*this);}
+    void accept(Visitor&);
 };
 
 // Document
@@ -69,7 +69,7 @@ class JSONDocument : public ASTNode
 {
   public:
     RValue* root;
-    void accept(Visitor& v) {v.visit(*this);}
+    void accept(Visitor&);
 };
 
 
@@ -88,11 +88,11 @@ class JSON : public RValue
     //  list of declarations
     std::list<Record*> records;
     // cleanup memory
-    ~JSON() {for (Record* d : records) delete d;}
+    ~JSON();
     // return first token (first primitive value)
-    Token first_token() {return this->records.size() ? this->records.front()->key : this->rbrace_token;}
+    Token first_token();
     // visitor access
-    void accept(Visitor& v) {v.visit(*this);}
+    void accept(Visitor&);
 };
 
 
@@ -106,11 +106,11 @@ class Array : public RValue
     // list of elements
     std::list<RValue*> values;
     // cleanup memory
-    ~Array() {for (RValue* v : values) delete v;}
+    ~Array();
     // return first token (first primitive value)
-    Token first_token() {return this->values.size() ? this->values.front()->first_token() : this->rbracket_token;}
+    Token first_token();
     // visitor access
-    void accept(Visitor& v) {v.visit(*this);}
+    void accept(Visitor&);
 };
 
 
@@ -120,10 +120,10 @@ class SimpleRValue : public RValue
     // primitive value
     Token value;
     // return first token
-    Token first_token() {return value;}
+    Token first_token();
     // visitor access
-    void accept(Visitor& v) {v.visit(*this);}
+    void accept(Visitor&);
 };
 
 
-#endif
+#endif // ifndef AST_H

--- a/lib/core/json_exception.cpp
+++ b/lib/core/json_exception.cpp
@@ -1,0 +1,35 @@
+#ifndef JSON_EXCEPTION_CPP
+#define JSON_EXCEPTION_CPP
+
+#include <string>
+#include "json_exception.h"
+
+JSONException::JSONException(ExceptionType t, const std::string& m, int l, int c)
+  : type(t), message(m), line(l), column(c), has_line_column(true)
+{
+}
+
+
+JSONException::JSONException(ExceptionType t, const std::string& m)
+  : type(t), message(m), has_line_column(false)
+{
+}
+
+
+std::string JSONException::to_string() const
+{
+  std::string s;
+  switch(type) {
+    case LEXER: s = "Lexer"; break;
+    case SYNTAX: s = "Parser"; break;
+    case SEMANTIC: s = "Type"; break;
+  }
+  s += " Error: " + message;
+  if (has_line_column)
+    s += " at line " + std::to_string(line) +
+      " column " + std::to_string(column);
+  return s;
+}
+
+
+#endif // ifndef JSON_EXCEPTION_CPP

--- a/lib/core/json_exception.h
+++ b/lib/core/json_exception.h
@@ -1,5 +1,5 @@
-#ifndef JSON_EXCEPTION
-#define JSON_EXCEPTION
+#ifndef JSON_EXCEPTION_H
+#define JSON_EXCEPTION_H
 
 #include <string>
 
@@ -7,16 +7,16 @@
 enum ExceptionType {LEXER, SYNTAX, SEMANTIC};
 
 
-// specialized exception for json implementation
+// specialized exception for wjson implementation
 class JSONException : public std::exception
 {
  public:
 
   // construct a "normal" error exception
-  JSONException(ExceptionType type, const std::string& msg, int line, int column);
+  JSONException(ExceptionType, const std::string&, int, int);
 
   // construct an error exception without a line and column
-  JSONException(ExceptionType type, const std::string& msg);
+  JSONException(ExceptionType, const std::string&);
 
   // return a string representation for printing
   std::string to_string() const;
@@ -32,32 +32,4 @@ class JSONException : public std::exception
 };
 
 
-JSONException::JSONException(ExceptionType t, const std::string& m, int l, int c)
-  : type(t), message(m), line(l), column(c), has_line_column(true)
-{
-}
-
-
-JSONException::JSONException(ExceptionType t, const std::string& m)
-  : type(t), message(m), has_line_column(false)
-{
-}
-
-
-std::string JSONException::to_string() const
-{
-  std::string s;
-  switch(type) {
-    case LEXER: s = "Lexer"; break;
-    case SYNTAX: s = "Parser"; break;
-    case SEMANTIC: s = "Type"; break;
-  }
-  s += " Error: " + message;
-  if (has_line_column)
-    s += " at line " + std::to_string(line) +
-      " column " + std::to_string(column);
-  return s;
-}
-
-
-#endif
+#endif // ifndef JSON_EXCEPTION_H

--- a/lib/core/lexer.cpp
+++ b/lib/core/lexer.cpp
@@ -1,0 +1,220 @@
+#ifndef LEXER_CPP
+#define LEXER_CPP
+
+
+#include <istream>
+#include <string>
+#include "lexer.h"
+
+bool Lexer::isValidIdentifier(int c)
+{
+	return c == '_' || isalnum(c);
+}
+
+bool Lexer::skipNextChar(const char& c)
+{
+	return isspace(c);
+}
+
+Lexer::Lexer(std::istream& input_stream)
+	: input_stream(input_stream), line(1), column(1)
+{
+}
+
+
+char Lexer::read()
+{
+	return input_stream.get();
+}
+
+int Lexer::read(char* buf, const int& n)
+{
+	input_stream.read(buf, n);
+	return input_stream.gcount();
+}
+
+unsigned int Lexer::read_u32(const int& n)
+{
+	unsigned int val = 0;
+	int len = n > 4 ? 4 : n;
+	switch(len) {
+		case 4:
+			val |= read() << 24;
+		case 3:
+			val |= read() << 16;
+		case 2:
+			val |= read() << 8;
+		case 1:
+			val |= read();
+	}
+	column += n;
+	return val;
+}
+
+char Lexer::peek()
+{
+	return input_stream.peek();
+}
+
+
+void Lexer::error(const std::string& msg, int line, int column) const
+{
+	throw JSONException(LEXER, msg, line, column);
+}
+
+char Lexer::readNextChar()
+{
+	column += 1;
+	return read();
+}
+
+Token Lexer::next_token()
+{
+	Token token;
+	char nextChar;
+	std::string lexeme = "";
+	while(skipNextChar(peek()))
+	{
+		nextChar = read();
+		if(nextChar == '\n')
+		{
+			line += 1;
+			column = 1;
+		} else {
+			column += 1;
+		}
+	}
+	int startColumn = column;
+	int startLine = line;
+	nextChar = readNextChar();
+	lexeme += nextChar;
+	switch(nextChar) {
+		case EOF:
+			token = Token(EOS, "", startLine, startColumn);
+			break;
+		case '{':
+			token = Token(LBRACE, "{", startLine, startColumn);
+			break;
+		case '}':
+			token = Token(RBRACE, "}", startLine, startColumn);
+			break;
+		case '[':
+			token = Token(LBRACKET, "[", startLine, startColumn);
+			break;
+		case ']':
+			token = Token(RBRACKET, "]", startLine, startColumn);
+			break;
+		case ':':
+			token = Token(COLON, ":", startLine, startColumn);
+			break;
+		case ',':
+			token = Token(COMMA, ",", startLine, startColumn);
+			break;
+		case '"':
+			// string
+			lexeme = "";
+			while(peek() != '"')
+			{
+				nextChar = readNextChar();
+				if(nextChar == '\\') //handle escapes (primarily for quote escape)
+				{
+					lexeme += nextChar;
+					nextChar = readNextChar();
+				}
+				if(nextChar == EOF || nextChar == '\n')
+				{
+					error("Invalid token '\"" + lexeme + "': string values require an opening and closing quotation mark,", startLine, startColumn);
+				}
+				lexeme += nextChar;
+			}
+			nextChar = readNextChar();
+			token = Token(STRING_VAL, lexeme, startLine, startColumn);
+			break;
+		default:
+			if(isdigit(nextChar) || nextChar == '-')
+			{
+				if(nextChar == '-')
+				{
+					nextChar = readNextChar();
+					lexeme += nextChar;
+					if(!isdigit(nextChar)) {
+						error("Invalid token,", startLine, startColumn);
+					}
+				}
+				bool leadingZero = nextChar == '0';
+				if(leadingZero && peek() == '0') {
+					error("Invalid token: leading 0's are not allowed,", startLine, startColumn);
+				}
+				while(isdigit(peek()))
+				{
+					nextChar = readNextChar();
+					lexeme += nextChar;
+				}
+				if(peek() == '.')
+				{
+					// double literal
+					nextChar = readNextChar();
+					lexeme += nextChar;
+					// need to finish reading numbers in
+					if(!isdigit(peek()))
+					{
+						// no numbers after dot error
+						error("Invalid token: '" + lexeme + "': double values must have at least one trailing digit,", startLine, startColumn);
+					}
+					while(isdigit(peek()))
+					{
+						nextChar = readNextChar();
+						lexeme += nextChar;
+					}
+				}
+				if(peek() == 'e' || peek() == 'E')
+				{
+					nextChar = readNextChar();
+					lexeme += nextChar;
+					nextChar = readNextChar();
+					if(nextChar == '-' || nextChar == '+')
+					{
+						lexeme += nextChar;
+						nextChar = readNextChar();
+					}
+					if(!isdigit(nextChar))
+					{
+						error("Invalid token: '" + lexeme + "':", startLine, startColumn);
+					}
+					lexeme += nextChar;
+					while(isdigit(peek()))
+					{
+						nextChar = readNextChar();
+						lexeme += nextChar;
+					}
+				}
+				token = Token(NUMBER_VAL, lexeme, startLine, startColumn);
+			} else if(nextChar == 't') {
+				const unsigned int MAGIC_NUMBER = 0x727565;
+				unsigned int buf = read_u32(3);
+				if(~(buf ^~ MAGIC_NUMBER)) {
+					error("Invalid token '\"" + lexeme + "'", startLine, startColumn);
+				}
+				token = Token(LITERAL_VAL, "true", startLine, startColumn);
+			} else if(nextChar == 'f') {
+				const unsigned int MAGIC_NUMBER = 0x616c7365;
+				unsigned int buf = read_u32(4);
+				if(~(buf ^~ MAGIC_NUMBER)) {
+					error("Invalid token '\"" + lexeme + "'", startLine, startColumn);
+				}
+				token = Token(LITERAL_VAL, "false", startLine, startColumn);
+			} else if(nextChar == 'n') {
+				const unsigned int MAGIC_NUMBER = 0x756c6c;
+				unsigned int buf = read_u32(3);
+				if(~(buf ^~ MAGIC_NUMBER)) {
+					error("Invalid token '\"" + lexeme + "'", startLine, startColumn);
+				}
+				token = Token(LITERAL_VAL, "null", startLine, startColumn);
+			} else {
+				error("Invalid token '\"" + lexeme + "'", startLine, startColumn);
+			}
+	}
+	return token;
+}
+
+#endif // ifndef LEXER_CPP

--- a/lib/core/lexer.h
+++ b/lib/core/lexer.h
@@ -7,14 +7,15 @@
 #include "token.h"
 #include "json_exception.h"
 
-#include <iostream>
-
 class Lexer
 {
 	public:
+		static bool isValidIdentifier(int);
+
+		static bool skipNextChar(const char&);
 
 		// construct a new lexer from the input stream
-		Lexer(std::istream& input_stream);
+		Lexer(std::istream&);
 
 		// return the next available token in the input stream (including
 		// EOS if at the end of the stream)
@@ -34,14 +35,14 @@ class Lexer
 		// returns actual number of characters read
 		int read(char* buf, const int& n);
 
-		// read up to the next 4 characters as bytes and return as a 32-bit integer
-		unsigned int read_u32(const int& n);
+		// read up to the next 4 characters as bytes and return as a 32-bit unsigned integer
+		unsigned int read_u32(const int&);
 
 		// return a single character from the input stream without advancing
 		char peek();
 
 		// create and throw a mypl_exception (exits the lexer)
-		void error(const std::string& msg, int line, int column) const;
+		void error(const std::string&, int, int) const;
 
 		// reads the next character using Lexer::read() and increments column
 		// (new lines get handled without this function being called)
@@ -49,215 +50,4 @@ class Lexer
 };
 
 
-Lexer::Lexer(std::istream& input_stream)
-	: input_stream(input_stream), line(1), column(1)
-{
-}
-
-
-char Lexer::read()
-{
-	return input_stream.get();
-}
-
-int Lexer::read(char* buf, const int& n)
-{
-	input_stream.read(buf, n);
-	return input_stream.gcount();
-}
-
-unsigned int Lexer::read_u32(const int& n)
-{
-	unsigned int val = 0;
-	int len = n > 4 ? 4 : n;
-	switch(len) {
-		case 4:
-			val |= read() << 24;
-		case 3:
-			val |= read() << 16;
-		case 2:
-			val |= read() << 8;
-		case 1:
-			val |= read();
-	}
-	column += n;
-	return val;
-}
-
-char Lexer::peek()
-{
-	return input_stream.peek();
-}
-
-
-void Lexer::error(const std::string& msg, int line, int column) const
-{
-	throw JSONException(LEXER, msg, line, column);
-}
-
-char Lexer::readNextChar()
-{
-	column += 1;
-	return read();
-}
-
-bool isValidIdentifier(int c)
-{
-	return c == '_' || isalnum(c);
-}
-
-bool skipNextChar(const char& c)
-{
-	return isspace(c);
-}
-
-Token Lexer::next_token()
-{
-	Token token;
-	char nextChar;
-	std::string lexeme = "";
-	while(skipNextChar(peek()))
-	{
-		nextChar = read();
-		if(nextChar == '\n')
-		{
-			line += 1;
-			column = 1;
-		} else {
-			column += 1;
-		}
-	}
-	int startColumn = column;
-	int startLine = line;
-	nextChar = readNextChar();
-	lexeme += nextChar;
-	switch(nextChar) {
-		case EOF:
-			token = Token(EOS, "", startLine, startColumn);
-			break;
-		case '{':
-			token = Token(LBRACE, "{", startLine, startColumn);
-			break;
-		case '}':
-			token = Token(RBRACE, "}", startLine, startColumn);
-			break;
-		case '[':
-			token = Token(LBRACKET, "[", startLine, startColumn);
-			break;
-		case ']':
-			token = Token(RBRACKET, "]", startLine, startColumn);
-			break;
-		case ':':
-			token = Token(COLON, ":", startLine, startColumn);
-			break;
-		case ',':
-			token = Token(COMMA, ",", startLine, startColumn);
-			break;
-		case '"':
-			// string
-			lexeme = "";
-			while(peek() != '"')
-			{
-				nextChar = readNextChar();
-				if(nextChar == '\\') //handle escapes (primarily for quote escape)
-				{
-					lexeme += nextChar;
-					nextChar = readNextChar();
-				}
-				if(nextChar == EOF || nextChar == '\n')
-				{
-					error("Invalid token '\"" + lexeme + "': string values require an opening and closing quotation mark,", startLine, startColumn);
-				}
-				lexeme += nextChar;
-			}
-			nextChar = readNextChar();
-			token = Token(STRING_VAL, lexeme, startLine, startColumn);
-			break;
-		default:
-			if(isdigit(nextChar) || nextChar == '-')
-			{
-				if(nextChar == '-')
-				{
-					nextChar = readNextChar();
-					lexeme += nextChar;
-					if(!isdigit(nextChar)) {
-						error("Invalid token,", startLine, startColumn);
-					}
-				}
-				bool leadingZero = nextChar == '0';
-				if(leadingZero && peek() == '0') {
-					error("Invalid token: leading 0's are not allowed,", startLine, startColumn);
-				}
-				while(isdigit(peek()))
-				{
-					nextChar = readNextChar();
-					lexeme += nextChar;
-				}
-				if(peek() == '.')
-				{
-					// double literal
-					nextChar = readNextChar();
-					lexeme += nextChar;
-					// need to finish reading numbers in
-					if(!isdigit(peek()))
-					{
-						// no numbers after dot error
-						error("Invalid token: '" + lexeme + "': double values must have at least one trailing digit,", startLine, startColumn);
-					}
-					while(isdigit(peek()))
-					{
-						nextChar = readNextChar();
-						lexeme += nextChar;
-					}
-				}
-				if(peek() == 'e' || peek() == 'E')
-				{
-					nextChar = readNextChar();
-					lexeme += nextChar;
-					nextChar = readNextChar();
-					if(nextChar == '-' || nextChar == '+')
-					{
-						lexeme += nextChar;
-						nextChar = readNextChar();
-					}
-					if(!isdigit(nextChar))
-					{
-						error("Invalid token: '" + lexeme + "':", startLine, startColumn);
-					}
-					lexeme += nextChar;
-					while(isdigit(peek()))
-					{
-						nextChar = readNextChar();
-						lexeme += nextChar;
-					}
-				}
-				token = Token(NUMBER_VAL, lexeme, startLine, startColumn);
-			} else if(nextChar == 't') {
-				const unsigned int MAGIC_NUMBER = 0x727565;
-				unsigned int buf = read_u32(3);
-				if(~(buf ^~ MAGIC_NUMBER)) {
-					error("Invalid token '\"" + lexeme + "'", startLine, startColumn);
-				}
-				token = Token(LITERAL_VAL, "true", startLine, startColumn);
-			} else if(nextChar == 'f') {
-				const unsigned int MAGIC_NUMBER = 0x616c7365;
-				unsigned int buf = read_u32(4);
-				if(~(buf ^~ MAGIC_NUMBER)) {
-					error("Invalid token '\"" + lexeme + "'", startLine, startColumn);
-				}
-				token = Token(LITERAL_VAL, "false", startLine, startColumn);
-			} else if(nextChar == 'n') {
-				const unsigned int MAGIC_NUMBER = 0x756c6c;
-				unsigned int buf = read_u32(3);
-				if(~(buf ^~ MAGIC_NUMBER)) {
-					error("Invalid token '\"" + lexeme + "'", startLine, startColumn);
-				}
-				token = Token(LITERAL_VAL, "null", startLine, startColumn);
-			} else {
-				error("Invalid token '\"" + lexeme + "'", startLine, startColumn);
-			}
-	}
-	return token;
-}
-
-#endif
+#endif // ifndef LEXER_H

--- a/lib/core/parser.cpp
+++ b/lib/core/parser.cpp
@@ -1,0 +1,189 @@
+#ifndef PARSER_CPP
+#define PARSER_CPP
+
+#include "parser.h"
+
+
+// constructor
+Parser::Parser(const Lexer& json_lexer) : lexer(json_lexer)
+{
+}
+
+
+// Helper functions
+
+void Parser::advance()
+{
+	curr_token = lexer.next_token();
+}
+
+
+void Parser::eat(TokenType t, std::string err_msg)
+{
+	if (curr_token.type() == t)
+		advance();
+	else
+		error(err_msg);
+}
+
+
+void Parser::error(std::string err_msg)
+{
+	std::string s = err_msg + "found '" + curr_token.lexeme() + "'";
+	this->base_error(s);
+}
+
+
+// same as error(), but the error message is entirely parameter supplied
+void Parser::base_error(std::string err_msg)
+{
+	int line = curr_token.line();
+	int col = curr_token.column();
+	throw JSONException(SYNTAX, err_msg, line, col);
+}
+
+
+// Recursive-decent functions
+
+void Parser::parse(JSONDocument& doc)
+{
+	advance();
+	rvalue(doc.root);
+	eat(EOS, "Unexpected token: expected end-of-file, ");
+}
+
+
+// Values
+
+void Parser::json(JSON& node)
+{
+	eat(LBRACE, "Unexpected token: expected '{', ");
+	records(node.records);
+	eat(RBRACE, "Unexpected token: expected ',', ");
+}
+
+void Parser::records(std::list<Record*>& records)
+{
+	if(curr_token.type() == RBRACE) return;
+
+	while(1)
+	{
+		Record* r = new Record;
+		record(*r);
+		records.push_back(r);
+		if(curr_token.type() != COMMA) {
+			break;
+		}
+		advance();
+	}
+}
+
+void Parser::record(Record& node)
+{
+	node.key = curr_token;
+	kval();
+	eat(COLON, "Unexpected token: expected ':', ");
+	rvalue(node.value);
+}
+
+void Parser::array(Array& node)
+{
+	eat(LBRACKET, "Unexpected token: expected '[', "); // Should never throw
+	values(node.values);
+	eat(RBRACKET, "Unexpected token: expected ']', ");
+}
+
+void Parser::values(std::list<RValue*>& vals)
+{
+	if(curr_token.type() == RBRACKET) return;
+
+	while(1)
+	{
+		RValue* r;
+		rvalue(r);
+		vals.push_back(r);
+		if(curr_token.type() != COMMA) {
+			break;
+		}
+		advance();
+	}
+}
+
+void Parser::simple(SimpleRValue& node)
+{
+	node.value = curr_token;
+	pval();
+	switch(node.value.type())
+	{
+		case LITERAL_VAL:
+			node.type = LITERAL_TYPE;
+			break;
+		case NUMBER_VAL:
+			node.type = NUMBER_TYPE;
+			break;
+		case STRING_VAL:
+			node.type = STRING_TYPE;
+			break;
+		default:
+			// unreachable
+			error("Unexpected token: ");
+			break;
+	}
+}
+
+void Parser::rvalue(RValue*& rval)
+{
+	switch(curr_token.type())
+	{
+		case LBRACE:
+		{
+			JSON* node = new JSON;
+			json(*node);
+			rval = node;
+			break;
+		}
+		case LBRACKET:
+		{
+			Array* node = new Array;
+			array(*node);
+			rval = node;
+			break;
+		}
+		default:
+		{
+			SimpleRValue* node = new SimpleRValue;
+			simple(*node);
+			rval = node;
+			break;
+		}
+	}
+}
+
+
+// Type checks
+void Parser::kval()
+{
+	if(curr_token.type() == STRING_VAL)
+	{
+		advance();
+	} else {
+		error("Unexpected token: expected string, ");
+	}
+}
+
+void Parser::pval()
+{
+	switch(curr_token.type())
+	{
+		case LITERAL_VAL:
+		case NUMBER_VAL:
+		case STRING_VAL:
+			advance();
+			break;
+		default:
+			error("Unexpected token: expected value, ");
+	}
+}
+
+
+#endif // ifndef PARSER_CPP

--- a/lib/core/parser.h
+++ b/lib/core/parser.h
@@ -11,10 +11,10 @@ class Parser
 {
 public:
 	// create a new recursive descent parser
-	Parser(const Lexer& json_lexer);
+	Parser(const Lexer&);
 
 	// run the parser
-	void parse(JSONDocument& doc);
+	void parse(JSONDocument&);
 
 private:
 	Lexer lexer;
@@ -22,18 +22,18 @@ private:
 
 	// helper functions
 	void advance();
-	void eat(TokenType t, std::string err_msg);
-	void error(std::string err_msg);
-	void base_error(std::string err_msg);
+	void eat(TokenType t, std::string);
+	void error(std::string);
+	void base_error(std::string);
 
 	// recursive descent functions
-    void json(JSON& node);
-    void records(std::list<Record*>& records);
-    void record(Record& node);
-    void array(Array& node);
-	void values(std::list<RValue*>& vals);
-    void simple(SimpleRValue& node);
-    void rvalue(RValue*& rval);
+    void json(JSON&);
+    void records(std::list<Record*>&);
+    void record(Record&);
+    void array(Array&);
+	void values(std::list<RValue*>&);
+    void simple(SimpleRValue&);
+    void rvalue(RValue*&);
 
 	// Type checks
     void kval();
@@ -41,186 +41,4 @@ private:
 };
 
 
-// constructor
-Parser::Parser(const Lexer& json_lexer) : lexer(json_lexer)
-{
-}
-
-
-// Helper functions
-
-void Parser::advance()
-{
-	curr_token = lexer.next_token();
-}
-
-
-void Parser::eat(TokenType t, std::string err_msg)
-{
-	if (curr_token.type() == t)
-		advance();
-	else
-		error(err_msg);
-}
-
-
-void Parser::error(std::string err_msg)
-{
-	std::string s = err_msg + "found '" + curr_token.lexeme() + "'";
-	this->base_error(s);
-}
-
-
-// same as error(), but the error message is entirely parameter supplied
-void Parser::base_error(std::string err_msg)
-{
-	int line = curr_token.line();
-	int col = curr_token.column();
-	throw JSONException(SYNTAX, err_msg, line, col);
-}
-
-
-// Recursive-decent functions
-
-void Parser::parse(JSONDocument& doc)
-{
-	advance();
-	rvalue(doc.root);
-	eat(EOS, "Unexpected token: expected end-of-file, ");
-}
-
-
-// Values
-
-void Parser::json(JSON& node)
-{
-	eat(LBRACE, "Unexpected token: expected '{', ");
-	records(node.records);
-	eat(RBRACE, "Unexpected token: expected ',', ");
-}
-
-void Parser::records(std::list<Record*>& records)
-{
-	if(curr_token.type() == RBRACE) return;
-
-	while(1)
-	{
-		Record* r = new Record;
-		record(*r);
-		records.push_back(r);
-		if(curr_token.type() != COMMA) {
-			break;
-		}
-		advance();
-	}
-}
-
-void Parser::record(Record& node)
-{
-	node.key = curr_token;
-	kval();
-	eat(COLON, "Unexpected token: expected ':', ");
-	rvalue(node.value);
-}
-
-void Parser::array(Array& node)
-{
-	eat(LBRACKET, "Unexpected token: expected '[', "); // Should never throw
-	values(node.values);
-	eat(RBRACKET, "Unexpected token: expected ']', ");
-}
-
-void Parser::values(std::list<RValue*>& vals)
-{
-	if(curr_token.type() == RBRACKET) return;
-
-	while(1)
-	{
-		RValue* r;
-		rvalue(r);
-		vals.push_back(r);
-		if(curr_token.type() != COMMA) {
-			break;
-		}
-		advance();
-	}
-}
-
-void Parser::simple(SimpleRValue& node)
-{
-	node.value = curr_token;
-	pval();
-	switch(node.value.type())
-	{
-		case LITERAL_VAL:
-			node.type = LITERAL_TYPE;
-			break;
-		case NUMBER_VAL:
-			node.type = NUMBER_TYPE;
-			break;
-		case STRING_VAL:
-			node.type = STRING_TYPE;
-			break;
-		default:
-			// unreachable
-			error("Unexpected token: ");
-			break;
-	}
-}
-
-void Parser::rvalue(RValue*& rval)
-{
-	switch(curr_token.type())
-	{
-		case LBRACE:
-		{
-			JSON* node = new JSON;
-			json(*node);
-			rval = node;
-			break;
-		}
-		case LBRACKET:
-		{
-			Array* node = new Array;
-			array(*node);
-			rval = node;
-			break;
-		}
-		default:
-		{
-			SimpleRValue* node = new SimpleRValue;
-			simple(*node);
-			rval = node;
-			break;
-		}
-	}
-}
-
-
-// Type checks
-void Parser::kval()
-{
-	if(curr_token.type() == STRING_VAL)
-	{
-		advance();
-	} else {
-		error("Unexpected token: expected string, ");
-	}
-}
-
-void Parser::pval()
-{
-	switch(curr_token.type())
-	{
-		case LITERAL_VAL:
-		case NUMBER_VAL:
-		case STRING_VAL:
-			advance();
-			break;
-		default:
-			error("Unexpected token: expected value, ");
-	}
-}
-
-
-#endif
+#endif // ifndef PARSER_H

--- a/lib/core/token.cpp
+++ b/lib/core/token.cpp
@@ -1,0 +1,54 @@
+// JSON parsing Token header
+
+#ifndef TOKEN_CPP
+#define TOKEN_CPP
+
+#include "token.h"
+
+// default constructor
+Token::Token()
+	: token_type(EOS), token_lexeme(""), token_line(0), token_column(0)
+{
+}
+
+// constructor
+Token::Token(TokenType type, const std::string& lexeme, int line, int column)
+	: token_type(type), token_lexeme(lexeme), token_line(line),
+	  token_column(column)
+{
+}
+
+// return the type of the token
+TokenType Token::type() const
+{
+	return token_type;
+}
+
+// return the token string value
+std::string Token::lexeme() const
+{
+	return token_lexeme;
+}
+
+// return the line location of lexeme
+int Token::line() const
+{
+	return token_line;
+}
+
+// return the column location where the lexeme starts
+int Token::column() const
+{
+	return token_column;
+}
+
+// a string representation of the token object
+std::string Token::to_string() const
+{
+	return token_type_map.find(token_type)->second +
+		" '" + lexeme() + "' " +
+		std::to_string(line()) + ":" + std::to_string(column());
+}
+
+
+#endif // ifndef TOKEN_CPP

--- a/lib/core/token.h
+++ b/lib/core/token.h
@@ -70,50 +70,5 @@ private:
 	};
 };
 
-// default constructor
-Token::Token()
-	: token_type(EOS), token_lexeme(""), token_line(0), token_column(0)
-{
-}
 
-// constructor
-Token::Token(TokenType type, const std::string& lexeme, int line, int column)
-	: token_type(type), token_lexeme(lexeme), token_line(line),
-	  token_column(column)
-{
-}
-
-// return the type of the token
-TokenType Token::type() const
-{
-	return token_type;
-}
-
-// return the token string value
-std::string Token::lexeme() const
-{
-	return token_lexeme;
-}
-
-// return the line location of lexeme
-int Token::line() const
-{
-	return token_line;
-}
-
-// return the column location where the lexeme starts
-int Token::column() const
-{
-	return token_column;
-}
-
-// a string representation of the token object
-std::string Token::to_string() const
-{
-	return token_type_map.find(token_type)->second +
-		" '" + lexeme() + "' " +
-		std::to_string(line()) + ":" + std::to_string(column());
-}
-
-
-#endif
+#endif // ifndef TOKEN_H

--- a/lib/printer/printer.h
+++ b/lib/printer/printer.h
@@ -1,0 +1,42 @@
+#ifndef PRINTER_H
+#define PRINTER_H
+
+#include <iostream>
+#include <string>
+
+// libwjson core modules
+#include <core/token.h>
+#include <core/ast.h>
+
+
+class Printer : public Visitor
+{
+public:
+	// constructors
+	Printer(std::ostream&);
+	Printer(std::ostream&, const int&);
+	Printer(std::ostream&, const int&, const char&);
+
+
+	// top-level
+	void visit(JSONDocument&);
+	void visit(JSON&);
+	void visit(Record&);
+	void visit(RValue&);
+	void visit(SimpleRValue&);
+	void visit(Array&);
+
+private:
+	const int indent_size;
+	const char indent_char;
+
+	std::ostream& out;
+	int curr_indent = 0;
+
+	void inc_indent();
+	void dec_indent();
+	std::string get_indent();
+};
+
+
+#endif // ifndef PRINTER_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+project(LIBWJSON_GTESTS)
+
+cmake_minimum_required(VERSION 3.0)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_FLAGS "-O0")
+set(CMAKE_BUILD_TYPE Debug)
+
+# add libwjson directory to include path
+include_directories(AFTER ../lib)
+
+# locate gtest
+find_package(GTest REQUIRED)
+include_directories(${GTEST_INCLUDE_DIRS})
+
+# create unit test executable
+add_executable(wjson_core_test
+               unit/core.test.cpp)
+target_link_libraries(wjson_core_test ${GTEST_LIBRARIES} pthread)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_BUILD_TYPE Debug)
 
 # add libwjson directory to include path
 include_directories(AFTER ../lib)
+include_directories(AFTER ../cli-utils)
 
 # locate gtest
 find_package(GTest REQUIRED)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(LIBWJSON_GTESTS)
+project(libwjson_gtests)
 
 cmake_minimum_required(VERSION 3.0)
 

--- a/tests/helpers.cpp
+++ b/tests/helpers.cpp
@@ -1,0 +1,68 @@
+#ifndef LWJ_TEST_HELPERS
+#define LWJ_TEST_HELPERS
+
+#include <string>
+#include <cstdio>
+#include <cstdlib>
+
+typedef unsigned long size_t;
+typedef unsigned char byte;
+typedef unsigned int uint;
+
+//----------------------------------------------------------------------
+// Helper functions for testing
+//----------------------------------------------------------------------
+
+/** Read file into memory. Derived from https://www.cplusplus.com/reference/cstdio/fread/ */
+inline byte* slurp(const std::string& path, long int& len) {
+  FILE* pFile;
+  byte* buf;
+  size_t result;
+
+  // open file
+  pFile = fopen(path.c_str(), "r");
+  if(pFile == NULL) {fputs(("File error: Could not open '" + path + '\'').c_str(), stderr); return nullptr;}
+  // obtain file size
+  fseek(pFile, 0, SEEK_END);
+  len = ftell(pFile);
+  rewind(pFile);
+  // allocate memory
+  buf = (byte*)malloc(sizeof(byte)*len);
+  if(buf == NULL) {fputs("Memory allocation error", stderr); fclose(pFile); return nullptr;}
+  // copy the file into the buffer:
+  result = fread(buf, 1, len, pFile);
+  if(result != len) {fputs("Reading error", stderr);if(!result){free(buf); fclose(pFile); return nullptr;}}
+  /* the whole file is now loaded in the memory buffer */
+  // cleanup
+  fclose(pFile);
+
+  return buf;
+}
+
+template<typename T>
+inline void unslurp(T*& p)
+{
+  if(p) free(p);
+  p = nullptr;
+}
+
+void readbuf(byte* p, size_t start, size_t length, byte out[])
+{
+  p += start;
+  for(size_t i = 0; i < length; ++i)
+  {
+    out[i] = *(p + i);
+  }
+}
+
+void readbuf(byte* p, size_t length, byte out[])
+{
+  readbuf(p, 0, length, out);
+}
+
+/* ASSERT_ARRAYEQ DEFINITION START */
+#define ASSERT_ARRAYEQ(arr1, arr2, len)\
+for(unsigned long i = 0; i < len; ++i) {ASSERT_EQ(arr1[i], arr2[i]);}
+/* END ASSERT_ARRAYEQ */
+
+#endif // ifndef LWJ_TEST_HELPERS

--- a/tests/unit/core.test.cpp
+++ b/tests/unit/core.test.cpp
@@ -110,6 +110,13 @@ TEST(WJSON_CORE, NumbersMisc) {
     TEST_AGAINST_PRINTER("{\"int\":3,\"another int\":103,\"negative\":-20,\"decimal\":1.3,\"leading 0 decimal\":0.5,\"negative decimal\":-51.92,\"negative leading 0 decimal\":-0.336,\"exp\":1e4,\"big exp\":2e21,\"bigger exp\":11e3,\"negative exp\":-4e5,\"exp with plus\":81e+1,\"exp with 0\":51e0,\"exp with minus\":37e-3,\"negative exp with plus\":-81e+1,\"negative exp with minus\":-23e-6,\"exp with frac and exp\":51.53e29}");
 }
 
+TEST(WJSON_COR, SimpleOneLine) {
+    // simpleOneLine.json is a single line JSON object with a useful range of value types represented,
+    // including arrays and null. It's actually already in the minimalist format our printer outputs
+    INPUT(simpleOneLine.json);
+    TEST_AGAINST_PRINTER("{\"configurations\":[{\"name\":\"config name\",\"includePath\":[\"{workspaceFolder}/**\"],\"defines\":[],\"frameworkPath\":[\"/my/framework/path/is/very/long/nice/frameworks\"],\"compilerPath\":\"/usr/bin/compilername\",\"cStandard\":\"c17\",\"cppStandard\":\"c++17\",\"intelliSenseMode\":\"os-compiler-arch\",\"i need another key\":true,\"again\":null},false],\"empty object\":{},\"version\":4}");
+}
+
 
 
 // Main

--- a/tests/unit/core.test.cpp
+++ b/tests/unit/core.test.cpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <iostream>
 #include <fstream>
+#include <sstream>
 
 // libwjson modules
 #include <core/token.cpp>
@@ -13,6 +14,9 @@
 // GTest
 #include <gtest/gtest.h>
 
+// wjsoncompact
+#include <wjsoncompact/wjsoncompact.cpp>
+
 //----------------------------------------------------------------------
 // Constants & Macros
 //----------------------------------------------------------------------
@@ -20,8 +24,10 @@
 #define TEST_FILES_DIR_PATH input_files
 #define TEST_FILE(file_name) GTEST_STRINGIFY_(TEST_FILES_DIR_PATH/file_name)
 #define TEST_SPEC_FILE(file_name) GTEST_STRINGIFY_(TEST_FILES_DIR_PATH/rfc8259_examples/file_name)
-#define INPUT(file_name) ifstream input(TEST_SPEC_FILE(file_name));\
-EXPECT_EQ(false, input.fail());
+#define INPUT_SPEC(file_name) ifstream input(TEST_SPEC_FILE(file_name));\
+EXPECT_EQ(false, input.fail())
+#define INPUT(file_name) ifstream input(TEST_FILE(file_name));\
+EXPECT_EQ(false, input.fail())
 
 //----------------------------------------------------------------------
 // libwjson/core Tests
@@ -29,11 +35,14 @@ EXPECT_EQ(false, input.fail());
 
 using namespace std;
 
-TEST(WJSON_CORE, Literal) {
-    INPUT(literal.json);
+// TEST SUITES
+// WJSON_CORE_SPEC - Tests against example JSON samples found in RFC8259
+// WJSON_CORE - Tests around the core modules
+
+TEST(WJSON_CORE_SPEC, Literal) {
+    INPUT_SPEC(literal.json);
 
     try {
-        // create the lexer & parser
         Lexer lexer(input);
         Parser parser(lexer);
         JSONDocument ast_root_node;
@@ -44,6 +53,89 @@ TEST(WJSON_CORE, Literal) {
         throw e;
     }
 }
+
+TEST(WJSON_CORE_SPEC, Number) {
+    INPUT_SPEC(number.json);
+
+    try {
+        Lexer lexer(input);
+        Parser parser(lexer);
+        JSONDocument ast_root_node;
+        parser.parse(ast_root_node);
+        EXPECT_STRCASEEQ("42", ast_root_node.root->first_token().lexeme().c_str());
+    } catch (JSONException e) {
+        cerr << e.to_string() << endl;
+        throw e;
+    }
+}
+
+TEST(WJSON_CORE_SPEC, String) {
+    INPUT_SPEC(string.json);
+
+    try {
+        Lexer lexer(input);
+        Parser parser(lexer);
+        JSONDocument ast_root_node;
+        parser.parse(ast_root_node);
+        // The quotation marks are not included in the stored lexeme
+        EXPECT_STRCASEEQ("Hello world!", ast_root_node.root->first_token().lexeme().c_str());
+    } catch (JSONException e) {
+        cerr << e.to_string() << endl;
+        throw e;
+    }
+}
+
+TEST(WJSON_CORE_SPEC, Object) {
+    INPUT_SPEC(rfc8259_obj_ex.json);
+
+    string rawJson = "{\"Image\":{\"Width\":800,\"Height\":600,\"Title\":\"View from 15th Floor\",\"Thumbnail\":{\"Url\":\"http://www.example.com/image/481989943\",\"Height\":125,\"Width\":100},\"Animated\":false,\"IDs\":[116,943,234,38793]}}";
+    ostringstream printerOut (ostringstream::ate);
+
+    try {
+        Lexer lexer(input);
+        Parser parser(lexer);
+        JSONDocument ast_root_node;
+        parser.parse(ast_root_node);
+
+        // We use the printer from wjsoncompact to create a minimilist representation of the AST.
+        // Be mindful that this does introduce an additional mode of failure
+        Printer printer(printerOut);
+        ast_root_node.accept(printer);
+
+        string parsedJson = printerOut.str();
+        EXPECT_STRCASEEQ(rawJson.c_str(), parsedJson.c_str());
+    } catch (JSONException e) {
+        cerr << e.to_string() << endl;
+        throw e;
+    }
+}
+
+TEST(WJSON_CORE_SPEC, Array) {
+    INPUT_SPEC(rfc8259_arr_ex.json);
+
+    string rawJson = "[{\"precision\":\"zip\",\"Latitude\":37.7668,\"Longitude\":-122.3959,\"Address\":\"\",\"City\":\"SAN FRANCISCO\",\"State\":\"CA\",\"Zip\":\"94107\",\"Country\":\"US\"},{\"precision\":\"zip\",\"Latitude\":37.371991,\"Longitude\":-122.026020,\"Address\":\"\",\"City\":\"SUNNYVALE\",\"State\":\"CA\",\"Zip\":\"94085\",\"Country\":\"US\"}]";
+    ostringstream printerOut (ostringstream::ate);
+
+    try {
+        Lexer lexer(input);
+        Parser parser(lexer);
+        JSONDocument ast_root_node;
+        parser.parse(ast_root_node);
+
+        // We use the printer from wjsoncompact to create a minimilist representation of the AST.
+        // Be mindful that this does introduce an additional mode of failure
+        Printer printer(printerOut);
+        ast_root_node.accept(printer);
+
+        string parsedJson = printerOut.str();
+        EXPECT_STRCASEEQ(rawJson.c_str(), parsedJson.c_str());
+    } catch (JSONException e) {
+        cerr << e.to_string() << endl;
+        throw e;
+    }
+}
+
+
 
 // Main
 int main(int argc, char** argv)

--- a/tests/unit/core.test.cpp
+++ b/tests/unit/core.test.cpp
@@ -14,12 +14,14 @@
 #include <gtest/gtest.h>
 
 //----------------------------------------------------------------------
-// Constants
+// Constants & Macros
 //----------------------------------------------------------------------
 
 #define TEST_FILES_DIR_PATH input_files
 #define TEST_FILE(file_name) GTEST_STRINGIFY_(TEST_FILES_DIR_PATH/file_name)
 #define TEST_SPEC_FILE(file_name) GTEST_STRINGIFY_(TEST_FILES_DIR_PATH/rfc8259_examples/file_name)
+#define INPUT(file_name) ifstream input(TEST_SPEC_FILE(file_name));\
+EXPECT_EQ(false, input.fail());
 
 //----------------------------------------------------------------------
 // libwjson/core Tests
@@ -28,12 +30,11 @@
 using namespace std;
 
 TEST(WJSON_CORE, Literal) {
-    ifstream input_stream(TEST_SPEC_FILE(literal.json));
-    EXPECT_EQ(false, input_stream.fail());
+    INPUT(literal.json);
 
     try {
         // create the lexer & parser
-        Lexer lexer(input_stream);
+        Lexer lexer(input);
         Parser parser(lexer);
         JSONDocument ast_root_node;
         parser.parse(ast_root_node);

--- a/tests/unit/core.test.cpp
+++ b/tests/unit/core.test.cpp
@@ -1,0 +1,52 @@
+// Standard library modules
+#include <string>
+#include <iostream>
+#include <fstream>
+
+// libwjson modules
+#include <core/token.cpp>
+#include <core/json_exception.cpp>
+#include <core/lexer.cpp>
+#include <core/parser.cpp>
+#include <core/ast.cpp>
+
+// GTest
+#include <gtest/gtest.h>
+
+//----------------------------------------------------------------------
+// Constants
+//----------------------------------------------------------------------
+
+#define TEST_FILES_DIR_PATH input_files
+#define TEST_FILE(file_name) GTEST_STRINGIFY_(TEST_FILES_DIR_PATH/file_name)
+#define TEST_SPEC_FILE(file_name) GTEST_STRINGIFY_(TEST_FILES_DIR_PATH/rfc8259_examples/file_name)
+
+//----------------------------------------------------------------------
+// libwjson/core Tests
+//----------------------------------------------------------------------
+
+using namespace std;
+
+TEST(WJSON_CORE, Literal) {
+    ifstream input_stream(TEST_SPEC_FILE(literal.json));
+    EXPECT_EQ(false, input_stream.fail());
+
+    try {
+        // create the lexer & parser
+        Lexer lexer(input_stream);
+        Parser parser(lexer);
+        JSONDocument ast_root_node;
+        parser.parse(ast_root_node);
+        EXPECT_STRCASEEQ("true", ast_root_node.root->first_token().lexeme().c_str());
+    } catch (JSONException e) {
+        cerr << e.to_string() << endl;
+        throw e;
+    }
+}
+
+// Main
+int main(int argc, char** argv)
+{
+	testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}

--- a/tests/unit/core.test.cpp
+++ b/tests/unit/core.test.cpp
@@ -117,6 +117,8 @@ TEST(WJSON_COR, SimpleOneLine) {
     TEST_AGAINST_PRINTER("{\"configurations\":[{\"name\":\"config name\",\"includePath\":[\"{workspaceFolder}/**\"],\"defines\":[],\"frameworkPath\":[\"/my/framework/path/is/very/long/nice/frameworks\"],\"compilerPath\":\"/usr/bin/compilername\",\"cStandard\":\"c17\",\"cppStandard\":\"c++17\",\"intelliSenseMode\":\"os-compiler-arch\",\"i need another key\":true,\"again\":null},false],\"empty object\":{},\"version\":4}");
 }
 
+// TODO: Add a test(s) that actually looks through the lexemes of something non-trivial
+
 
 
 // Main

--- a/tests/unit/core.test.cpp
+++ b/tests/unit/core.test.cpp
@@ -30,6 +30,41 @@ EXPECT_EQ(false, input.fail())
 EXPECT_EQ(false, input.fail())
 
 //----------------------------------------------------------------------
+// Test Body Macros
+//----------------------------------------------------------------------
+
+#define TEST_AGAINST_FIRST_TOKEN(expectedValue) try {\
+        Lexer lexer(input);\
+        Parser parser(lexer);\
+        JSONDocument ast_root_node;\
+        parser.parse(ast_root_node);\
+        EXPECT_STRCASEEQ(expectedValue, ast_root_node.root->first_token().lexeme().c_str());\
+    } catch (JSONException e) {\
+        cerr << e.to_string() << endl;\
+        throw e;\
+    }
+
+// We use the printer from wjsoncompact to create a minimilist representation of the AST.
+// Be mindful that this does introduce an additional mode of failure
+#define TEST_AGAINST_PRINTER(expectedValue) string rawJson = expectedValue;\
+    ostringstream printerOut (ostringstream::ate);\
+\
+    try {\
+        Lexer lexer(input);\
+        Parser parser(lexer);\
+        JSONDocument ast_root_node;\
+        parser.parse(ast_root_node);\
+        Printer printer(printerOut);\
+        ast_root_node.accept(printer);\
+\
+        string parsedJson = printerOut.str();\
+        EXPECT_STRCASEEQ(rawJson.c_str(), parsedJson.c_str());\
+    } catch (JSONException e) {\
+        cerr << e.to_string() << endl;\
+        throw e;\
+    }
+
+//----------------------------------------------------------------------
 // libwjson/core Tests
 //----------------------------------------------------------------------
 
@@ -41,98 +76,38 @@ using namespace std;
 
 TEST(WJSON_CORE_SPEC, Literal) {
     INPUT_SPEC(literal.json);
-
-    try {
-        Lexer lexer(input);
-        Parser parser(lexer);
-        JSONDocument ast_root_node;
-        parser.parse(ast_root_node);
-        EXPECT_STRCASEEQ("true", ast_root_node.root->first_token().lexeme().c_str());
-    } catch (JSONException e) {
-        cerr << e.to_string() << endl;
-        throw e;
-    }
+    TEST_AGAINST_FIRST_TOKEN("true");
 }
 
 TEST(WJSON_CORE_SPEC, Number) {
     INPUT_SPEC(number.json);
-
-    try {
-        Lexer lexer(input);
-        Parser parser(lexer);
-        JSONDocument ast_root_node;
-        parser.parse(ast_root_node);
-        EXPECT_STRCASEEQ("42", ast_root_node.root->first_token().lexeme().c_str());
-    } catch (JSONException e) {
-        cerr << e.to_string() << endl;
-        throw e;
-    }
+    TEST_AGAINST_FIRST_TOKEN("42");
 }
 
 TEST(WJSON_CORE_SPEC, String) {
     INPUT_SPEC(string.json);
-
-    try {
-        Lexer lexer(input);
-        Parser parser(lexer);
-        JSONDocument ast_root_node;
-        parser.parse(ast_root_node);
-        // The quotation marks are not included in the stored lexeme
-        EXPECT_STRCASEEQ("Hello world!", ast_root_node.root->first_token().lexeme().c_str());
-    } catch (JSONException e) {
-        cerr << e.to_string() << endl;
-        throw e;
-    }
+    // The quotation marks are not included in the stored lexeme
+    TEST_AGAINST_FIRST_TOKEN("Hello World!");
 }
 
 TEST(WJSON_CORE_SPEC, Object) {
     INPUT_SPEC(rfc8259_obj_ex.json);
-
-    string rawJson = "{\"Image\":{\"Width\":800,\"Height\":600,\"Title\":\"View from 15th Floor\",\"Thumbnail\":{\"Url\":\"http://www.example.com/image/481989943\",\"Height\":125,\"Width\":100},\"Animated\":false,\"IDs\":[116,943,234,38793]}}";
-    ostringstream printerOut (ostringstream::ate);
-
-    try {
-        Lexer lexer(input);
-        Parser parser(lexer);
-        JSONDocument ast_root_node;
-        parser.parse(ast_root_node);
-
-        // We use the printer from wjsoncompact to create a minimilist representation of the AST.
-        // Be mindful that this does introduce an additional mode of failure
-        Printer printer(printerOut);
-        ast_root_node.accept(printer);
-
-        string parsedJson = printerOut.str();
-        EXPECT_STRCASEEQ(rawJson.c_str(), parsedJson.c_str());
-    } catch (JSONException e) {
-        cerr << e.to_string() << endl;
-        throw e;
-    }
+    TEST_AGAINST_PRINTER("{\"Image\":{\"Width\":800,\"Height\":600,\"Title\":\"View from 15th Floor\",\"Thumbnail\":{\"Url\":\"http://www.example.com/image/481989943\",\"Height\":125,\"Width\":100},\"Animated\":false,\"IDs\":[116,943,234,38793]}}");
 }
 
 TEST(WJSON_CORE_SPEC, Array) {
     INPUT_SPEC(rfc8259_arr_ex.json);
+    TEST_AGAINST_PRINTER("[{\"precision\":\"zip\",\"Latitude\":37.7668,\"Longitude\":-122.3959,\"Address\":\"\",\"City\":\"SAN FRANCISCO\",\"State\":\"CA\",\"Zip\":\"94107\",\"Country\":\"US\"},{\"precision\":\"zip\",\"Latitude\":37.371991,\"Longitude\":-122.026020,\"Address\":\"\",\"City\":\"SUNNYVALE\",\"State\":\"CA\",\"Zip\":\"94085\",\"Country\":\"US\"}]");
+}
 
-    string rawJson = "[{\"precision\":\"zip\",\"Latitude\":37.7668,\"Longitude\":-122.3959,\"Address\":\"\",\"City\":\"SAN FRANCISCO\",\"State\":\"CA\",\"Zip\":\"94107\",\"Country\":\"US\"},{\"precision\":\"zip\",\"Latitude\":37.371991,\"Longitude\":-122.026020,\"Address\":\"\",\"City\":\"SUNNYVALE\",\"State\":\"CA\",\"Zip\":\"94085\",\"Country\":\"US\"}]";
-    ostringstream printerOut (ostringstream::ate);
 
-    try {
-        Lexer lexer(input);
-        Parser parser(lexer);
-        JSONDocument ast_root_node;
-        parser.parse(ast_root_node);
 
-        // We use the printer from wjsoncompact to create a minimilist representation of the AST.
-        // Be mindful that this does introduce an additional mode of failure
-        Printer printer(printerOut);
-        ast_root_node.accept(printer);
-
-        string parsedJson = printerOut.str();
-        EXPECT_STRCASEEQ(rawJson.c_str(), parsedJson.c_str());
-    } catch (JSONException e) {
-        cerr << e.to_string() << endl;
-        throw e;
-    }
+TEST(WJSON_CORE, NumbersMisc) {
+    // numbers.json has a JSON object with an assortment of valid JSON number values showcasing
+    // a range of lexical features (e.g. normal positive numbers, decimals, negative sign,
+    // scientific notation, etc)
+    INPUT(numbers.json);
+    TEST_AGAINST_PRINTER("{\"int\":3,\"another int\":103,\"negative\":-20,\"decimal\":1.3,\"leading 0 decimal\":0.5,\"negative decimal\":-51.92,\"negative leading 0 decimal\":-0.336,\"exp\":1e4,\"big exp\":2e21,\"bigger exp\":11e3,\"negative exp\":-4e5,\"exp with plus\":81e+1,\"exp with 0\":51e0,\"exp with minus\":37e-3,\"negative exp with plus\":-81e+1,\"negative exp with minus\":-23e-6,\"exp with frac and exp\":51.53e29}");
 }
 
 


### PR DESCRIPTION
- Initial pass at formal unit tests. Could still use more complete coverage of the standard, and a more intentional approach. Currently the tests are just a formalization with assertions around the test files that were already present.
- Includes a bit of restructuring, though not to the extent I'd like (would like to get proper `include/` and `usr/local/lib` headers and archives generated during compilation). 
- Includes a new `cli-util`, another printer, called `wjsoncompact`. This one prints a minimalist representation of the input JSON, i.e. removes all unnecessary whitespace

Resolves #1